### PR TITLE
feat: Add new Share CTA with multiple sharing options

### DIFF
--- a/app.js
+++ b/app.js
@@ -212,12 +212,14 @@ class AIFootRater {
         });
         
         // Action buttons
-        document.getElementById('shareBtn').addEventListener('click', () => this.shareResult());
+        document.getElementById('openShareModalBtn').addEventListener('click', () => this.shareResult());
         document.getElementById('newRatingBtn').addEventListener('click', () => this.resetApp());
         
         // Modal
         document.getElementById('closeModal').addEventListener('click', () => this.closeModal());
         document.getElementById('downloadBtn').addEventListener('click', () => this.downloadShare());
+        document.getElementById('shareBtn').addEventListener('click', () => this.shareImage());
+        document.getElementById('copyBtn').addEventListener('click', () => this.copyImage());
         
         // Modal overlay click to close
         document.querySelector('.modal-overlay').addEventListener('click', () => this.closeModal());
@@ -550,6 +552,47 @@ class AIFootRater {
         link.download = `foot-rating-${this.currentResult.score}.png`;
         link.href = canvas.toDataURL();
         link.click();
+    }
+
+    async shareImage() {
+        const canvas = document.getElementById('shareCanvas');
+        if (navigator.share) {
+            canvas.toBlob(async (blob) => {
+                const file = new File([blob], `foot-rating-${this.currentResult.score}.png`, { type: 'image/png' });
+                try {
+                    await navigator.share({
+                        files: [file],
+                        title: 'My AI Foot Rating!',
+                        text: `I got a ${this.currentResult.score}/10 on the AI Foot Rater!`,
+                    });
+                } catch (error) {
+                    console.error('Error sharing:', error);
+                }
+            }, 'image/png');
+        } else {
+            alert('Web Share API is not supported in your browser.');
+        }
+    }
+
+    copyImage() {
+        const canvas = document.getElementById('shareCanvas');
+        const copyBtn = document.getElementById('copyBtn');
+        canvas.toBlob((blob) => {
+            try {
+                navigator.clipboard.write([
+                    new ClipboardItem({
+                        'image/png': blob
+                    })
+                ]);
+                copyBtn.textContent = 'Copied!';
+                setTimeout(() => {
+                    copyBtn.textContent = 'Copy Image';
+                }, 2000);
+            } catch (error) {
+                console.error('Error copying image:', error);
+                alert('Failed to copy image.');
+            }
+        }, 'image/png');
     }
     
     closeModal() {

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
                     </div>
 
                     <div class="action-buttons">
-                        <button class="btn btn--primary" id="shareBtn">Share Result</button>
+                        <button class="btn btn--primary" id="openShareModalBtn">Share Result</button>
                         <button class="btn btn--secondary" id="newRatingBtn">Rate Another Foot</button>
                     </div>
                 </div>
@@ -136,7 +136,9 @@
             <div class="modal-body">
                 <canvas id="shareCanvas" width="400" height="600"></canvas>
                 <div class="share-actions">
-                    <button class="btn btn--primary" id="downloadBtn">Download Image</button>
+                    <button class="btn btn--primary" id="shareBtn">Share</button>
+                    <button class="btn btn--secondary" id="copyBtn">Copy Image</button>
+                    <button class="btn btn--secondary" id="downloadBtn">Download</button>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1248,6 +1248,9 @@ select.form-control {
 
 .share-actions {
   margin-top: var(--space-16);
+  display: flex;
+  gap: var(--space-12);
+  justify-content: center;
 }
 
 #shareCanvas {


### PR DESCRIPTION
This commit introduces a new Share CTA (Call to Action) that enhances the user's ability to share their AI-generated foot ratings.

Key changes:
- The "Share Result" button now opens a modal with three sharing options: "Share", "Copy Image", and "Download".
- The "Share" button utilizes the Web Share API (`navigator.share`) for native sharing to other apps.
- The "Copy Image" button uses the Clipboard API (`navigator.clipboard.write`) to copy the generated image to the user's clipboard.
- The "Download" button allows the user to save the image to their device.
- Button IDs have been updated for clarity to prevent confusion between the button that opens the modal and the share button within the modal.